### PR TITLE
#13 Fix gulp build-dev with force-reload

### DIFF
--- a/03 LiveReload/README.md
+++ b/03 LiveReload/README.md
@@ -58,13 +58,15 @@ gulp.task('force-reload', function() {
 });
 ```
 
-- Let's add this task at the end of the _build-dev_ process
+- Let's add this task at the end of the _watch_ process
 
 ```javascript
-gulp.task('build-dev', gulp.series('clean', 'copy-dev', 'force-reload'));
+gulp.task('watch', function() {
+  gulp.watch(['./src/**/*.html', './src/**/*.js'], gulp.series('build-dev', 'force-reload'))
+});
 ```
 
-- Now run _gulp build-dev_ process 
+- Now run _gulp build-dev_ process
 ```
 gulp build-dev
 ```

--- a/03 LiveReload/gulpfile.js
+++ b/03 LiveReload/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('connect', function() {
   });
 });
 
- 
+
  gulp.task('clean', function() {
    return del([
        'dist/**/*'
@@ -44,7 +44,7 @@ gulp.task('generate-prod-html', function() {
 });
 
 
-gulp.task('build-dev', gulp.series('clean', 'copy-dev', 'force-reload'));
+gulp.task('build-dev', gulp.series('clean', 'copy-dev'));
 
 gulp.task('create-bundle', function() {
     return gulp.src('./src/**/*.js')
@@ -56,7 +56,7 @@ gulp.task('create-bundle', function() {
 
 
 gulp.task('watch', function() {
-  gulp.watch(['./src/**/*.html', './src/**/*.js'], gulp.series('build-dev'))
+  gulp.watch(['./src/**/*.html', './src/**/*.js'], gulp.series('build-dev', 'force-reload'))
 });
 
 

--- a/04 SASS/README.md
+++ b/04 SASS/README.md
@@ -123,7 +123,7 @@ npm install gulp-sass --save-dev
 
   ```
   gulp.task('watch', function() {
-  gulp.watch(['./src/**/*.html', './src/**/*.js', './src/sass/**/*.scss'], gulp.series('build-dev'))
+  gulp.watch(['./src/**/*.html', './src/**/*.js', './src/sass/**/*.scss'], gulp.series('build-dev', 'force-reload'))
 });
   ```
   - Remembering a build-dev task and also adding minor changes: add the sass task
@@ -131,8 +131,7 @@ npm install gulp-sass --save-dev
   ```
   gulp.task('build-dev', gulp.series(
           'clean', 'copy-dev', 'sass',
-          gulp.parallel('generate-prod-js-html','create-bundle-js'),
-          'force-reload'));
+          gulp.parallel('generate-prod-js-html','create-bundle-js')));
   ```
 
 

--- a/04 SASS/gulpfile.js
+++ b/04 SASS/gulpfile.js
@@ -58,14 +58,13 @@ gulp.task('create-bundle-js', function() {
 
 gulp.task('build-dev', gulp.series(
           'clean', 'copy-dev', 'sass',
-          gulp.parallel('generate-prod-html','create-bundle-js'),
-          'force-reload'));
+          gulp.parallel('generate-prod-html','create-bundle-js')));
 
 
 
 
 gulp.task('watch', function() {
-  gulp.watch(['./src/**/*.html', './src/**/*.js', './src/sass/**/*.scss'], gulp.series('build-dev'))
+  gulp.watch(['./src/**/*.html', './src/**/*.js', './src/sass/**/*.scss'], gulp.series('build-dev', 'force-reload'))
 });
 
 


### PR DESCRIPTION
To fix gulp build-dev, I put 'force-reload' task inside watch task and I pull of build-dev. I also change the Readme that explain that.
